### PR TITLE
Add Dependabot config with 1-week cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` enabling weekly npm dependency updates with a 7-day cooldown so update PRs are held for a week after a release.

## Test plan
- [ ] Verify Dependabot picks up the config on the next scheduled run.